### PR TITLE
Add support for Nora Princess and Stray Cat Heart HD CUSA13303

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Currently this loader is specific for the following list of games:
 5. Aikagi Kimi to Issho ni Pack (CUSA16229)
 6. Aikagi 2 (CUSA19556)
 7. IxSHE Tell (CUSA17112)
+8. Nora Princess and Stray Cat Heart HD (CUSA13303) - Requires manual loading of savegame
+   - Rename save9999.dat into nora_01.dat.
 
 For guide on how to setup this loader, please refer [SETUP.md](SETUP.md)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,6 +6,7 @@
 3. Copy and paste all files from savedata into USB drive (x:\PS4\APOLLO\id_{YOUR_GAME_CUSA_ID}_savedata), overwriting currently existing save data
 4. Use Apollo Save Tool to import the new save data from USB drive
 5. Run the game and check if there is a popup from lua loader
+   - Some games require manual loading of save game, e.g. CUSA13303.
 6. Use `send_lua.py` to send lua file to the loader
 
 If you have a jailbroken PS5 with a non activated account, you can use [OffAct](https://github.com/ps5-payload-dev/websrv/releases) to offline activate the account and transfer save data with matching account ID using FTP.
@@ -36,4 +37,5 @@ If you have a jailbroken PS5 with a non activated account, you can use [OffAct](
 13. Connect your USB drive to the PS5/PS5 Slim/PS5 Pro.
 14. Use the PS5 settings menu to import the encrypted save data from the USB drive. (`Saved Data and Game/App Settings -> Saved Data (PS4) -> Copy or Delete from USB Drive -> Select your game and import`)
 15. Run the game and check if there is a popup from lua loader.
+    - Some games require manual loading of save game, e.g. CUSA13303.
 16. Use `send_lua.py` to send lua file to the loader.

--- a/payloads/ftp_server.lua
+++ b/payloads/ftp_server.lua
@@ -92,6 +92,11 @@ offsets = {
             time = 0xB4F00,
             gmtime = 0x3DA60,
             gmtime_s = 0x34790
+        },
+        nora_princess = {
+            time = 0x7FBB0,
+            gmtime = 0x9730,
+            gmtime_s = 0x1600
         }
     }
 }
@@ -106,6 +111,7 @@ function get_offsets(gamename)
     if gamename == "C" then add_offsets = offsets.libc.c end
     if gamename == "E" then add_offsets = offsets.libc.e end
     if gamename == "IxSHETell" then add_offsets = offsets.libc.ixshe_tell end
+    if gamename == "NoraPrincess" then add_offsets = offsets.libc.nora_princess end
 end
 
 function time(tloc)

--- a/savedata/lua.lua
+++ b/savedata/lua.lua
@@ -190,6 +190,11 @@ function lua.resolve_game(luaB_auxwrap)
         eboot_addrofs = gadget_table.ixshe_tell.eboot_addrofs
         libc_addrofs = gadget_table.ixshe_tell.libc_addrofs
         gadgets = gadget_table.ixshe_tell.gadgets
+    elseif game_name == "NoraPrincess" then
+        print("[+] Game identified as CUSA13303 Nora Princess and Stray Cat Heart HD")
+        eboot_addrofs = gadget_table.nora_princess.eboot_addrofs
+        libc_addrofs = gadget_table.nora_princess.libc_addrofs
+        gadgets = gadget_table.nora_princess.gadgets
     end
 end
 

--- a/savedata/offsets.lua
+++ b/savedata/offsets.lua
@@ -8,6 +8,7 @@ games_identification = {
     [0x280] = "C",
     [0x600] = "E",
     [0xd80] = "IxSHETell",
+    [0x660] = "NoraPrincess",  -- CUSA13303 Nora Princess and Stray Cat Heart HD
 }
 
 gadget_table = {
@@ -700,6 +701,100 @@ gadget_table = {
             Mtx_unlock = 0x576f0,
 
             Atomic_fetch_add_8 = 0x43900,
+        }
+    },
+    nora_princess = {
+        gadgets = {
+            ["ret"] = 0x4c,
+
+            ["pop rsp; ret"] = 0x982,
+            ["pop rbp; ret"] = 0x79,
+            ["pop rax; ret"] = 0x972,
+            ["pop rbx; ret"] = 0xd0b25,
+            ["pop rcx; ret"] = 0xc62,
+            ["pop rdx; ret"] = 0x249e2,
+            ["pop rdi; ret"] = 0x509cd,
+            ["pop rsi; ret"] = 0xe3534,
+            ["pop r8; ret"] = 0x971,
+
+            ["mov r9, rbx; call [rax + 8]"] = 0x14fc50,
+            -- or
+            ["pop r13; pop r14; pop r15; ret"] = 0x114543,
+            ["mov r9, r13; call [rax + 8]"] = 0x13ae54,
+
+            ["mov [rax + 8], rcx; ret"] = 0x13adda,
+            ["mov [rax + 0x28], rdx; ret"] = 0x14deaf,
+            ["mov [rcx + 0xa0], rdi; ret"] = 0xd4afe,
+            ["mov r9, [rax + rsi + 0x18]; xor eax, eax; mov [r8], r9; ret"] = 0x11b4f2,
+            ["add rax, r8; ret"] = 0xb423,
+
+            ["mov [rdi], rsi; ret"] = 0xd4ccf,
+            ["mov [rdi], rax; ret"] = 0x972db,
+            ["mov [rdi], eax; ret"] = nil,
+
+            ["add [rbx], eax; ret"] = 0x425a3b,
+            -- or
+            ["add [rbx], ecx; ret"] = nil,
+            -- or
+            ["add [rbx], edi; ret"] = 0x403ad3,
+
+            ["mov rax, [rax]; ret"] = 0x20e3b,
+            ["inc dword [rax]; ret"] = 0x199d7b,
+
+            -- branching specific gadgets
+            ["cmp [rax], ebx; ret"] = 0x405fc8,
+            ["sete al; ret"] = 0x5e495,
+            ["setne al; ret"] = 0x1f14e,
+            ["seta al; ret"] = 0x16c0ae,
+            ["setb al; ret"] = 0x5e4b4,
+            ["setg al; ret"] = nil,
+            ["setl al; ret"] = 0xcefda,
+            ["shl rax, cl; ret"] = 0xd9551,
+            ["add rax, rcx; ret"] = 0x366ee,
+
+            stack_pivot = {
+                ["mov esp, 0xfb0000bd; ret"] = 0x3b44d4, -- crash handler
+                ["mov esp, 0xf00000b9; ret"] = 0x3ba21c, -- native handler
+            }
+        },
+        eboot_addrofs = {
+            fake_string = 0x4D8164, -- SCE_RELRO segment, use ptr as size for fake string
+            luaB_auxwrap = 0x1A0660, -- to resolve eboot base
+            longjmp_import = 0x4F3C68, -- to resolve libc base
+
+            luaL_optinteger = 0x19E040,
+            luaL_checklstring = 0x19DC30,
+            lua_pushlstring = 0x19BD20,
+            lua_pushinteger = 0x19BD00,
+
+            luaL_newstate = 0x19EF90,
+            luaL_openlibs = 0x1A8FE0,
+            lua_setfield = 0x19C7E0,
+            luaL_loadstring = 0x19EF20,
+            lua_pcall = 0x19CE80,
+            lua_pushcclosure = 0x19BF30,
+            lua_tolstring = 0x19B430,
+            lua_pushstring = 0x19BD80,
+        },
+        libc_addrofs = {
+            calloc = 0x22A90,
+            memcpy = 0x18B90,
+            setjmp = 0x802A0,
+            longjmp = 0x802F0,
+            strerror = 0xCF70,
+            error = 0x13E,
+            sceKernelGetModuleInfoFromAddr = 0x568,
+            gettimeofday_import = 0xEFE20, -- syscall wrapper
+
+            Thrd_join = 0x21F00,
+            Thrd_exit = 0x21F80,
+            Thrd_create = 0x22090,
+
+            Mtx_init = 0x22320,
+            Mtx_lock = 0x223B0,
+            Mtx_unlock = 0x223A0,
+
+            Atomic_fetch_add_8 = 0xE380,
         }
     },
 }

--- a/savedata/uint64.lua
+++ b/savedata/uint64.lua
@@ -156,8 +156,15 @@ function uint64:divmod(v)
     return q, r
 end
 
-function uint64:__div(v) return select(1, self:divmod(v)) end
-function uint64:__mod(v) return select(2, self:divmod(v)) end
+function uint64:__div(v)
+    local q, _ = self:divmod(v)
+    return q
+end
+
+function uint64:__mod(v)
+    local _, r = self:divmod(v)
+    return r
+end
 
 
 --


### PR DESCRIPTION
Changes:
  - Add support for Nora Princess and Stray Cat Heart HD CUSA13303
  - Fixed `uint64:__div(v)` incorrectly returning both `q` and `r`. Noticed in CUSA13303

Big Thank you to @n0llptr for helping to troubleshoot and answering many questions.

Tested with CUSA13303 only, don't have any other working game to test with.

Issue: 
In `align_to`, `return v + (n - v % n) % n` was throwing a `nil` error.
  - specifically `v % n` was returning nil.

Upon investigation separating the `uint64:__div(v)` and `uint64:__mod(v)` to return `q` and `r` respectively worked.

Further investigation:

    function uint64:__div(v) return select(1, self:divmod(v)) end
    function uint64:__mod(v) return select(2, self:divmod(v)) end

Above taken from: https://github.com/shahrilnet/remote_lua_loader/blob/main/savedata/uint64.lua#L159C1-L160C62

`uint64:__div(v)` returns `q, r`. It should be returning `q`
docs: https://www.lua.org/manual/5.1/manual.html#pdf-select