### PR TITLE
Fix ELF support in the BIN loader

### DIFF
--- a/payloads/bin_loader.lua
+++ b/payloads/bin_loader.lua
@@ -40,7 +40,7 @@ local function load_elf_segments(buffer, base_addr)
             local seg_addr = base_addr + (p_vaddr % 0x1000000) -- use relative offset
             memory.memcpy(seg_addr, buffer + p_offset, p_filesz)
             if p_memsz > p_filesz then
-                memory.memset(seg_addr + p_filesz, 0, p_memsz - p_filesz)
+                -- memory.memset(seg_addr + p_filesz, 0, p_memsz - p_filesz)
             end
         end
     end


### PR DESCRIPTION
Fix ELF support in the BIN loader by assuming that the .bss sections is initialized by the payload.

Implementing memory.memset adds another offset to maintain, and forces users to manually update savedata.